### PR TITLE
Update wpdl-py-cross repository URL & replace zip download links with releases/latest

### DIFF
--- a/content/posts/linux.md
+++ b/content/posts/linux.md
@@ -27,7 +27,7 @@ This method involves running a precompiled version of [ZhiFenBL](https://github.
 
 ### wpdl-py-cross (Python):
 
-This method involves running [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/ZhiFenBL/wpdl-py-cross" "wpdl-py-cross" >}} using a python virtual environment.
+This method involves running [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}} using a python virtual environment.
 
 *The following guide is written using* `apt`*. For non Debian-based distros, use your native package manager. Please note that package names may differ.*
 

--- a/content/posts/linux.md
+++ b/content/posts/linux.md
@@ -17,9 +17,9 @@ There are six ways to run a Wattpad downloader on Linux: wpd.my, wpdl-py-cross (
 
 Using the wpdl-py-cross (precompiled) method if by far the easiest way to download stories from Wattpad. Choose this option if you aren't sure what to pick.
 
-This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/ZhiFenBL/wpdl-py-cross" "wpdl-py-cross" >}}.
+This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}}.
 
-1) Download the Linux `.zip` from  [Github](https://github.com/ZhiFenBL/bin-wpdl-py/releases/download/v0.0.1/linux-build-v0.0.1.zip).
+1) Download the Linux `linus-build-v*.*.*.zip` from  {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "GitHub" >}}..
 
 2) Extract the `.zip` file.
 

--- a/content/posts/linux.md
+++ b/content/posts/linux.md
@@ -19,7 +19,7 @@ Using the wpdl-py-cross (precompiled) method if by far the easiest way to downlo
 
 This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}}.
 
-1) Download the Linux `linus-build-v*.*.*.zip` from  {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "GitHub" >}}..
+1) Download the Linux `linus-build-v*.*.*.zip` from  {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "GitHub" >}}.
 
 2) Extract the `.zip` file.
 

--- a/content/posts/macos.md
+++ b/content/posts/macos.md
@@ -17,9 +17,9 @@ There are six ways to run a Wattpad downloader on MacOS: wpd.my, wpdl-py-cross (
 
 Using the wpdl-py-cross (precompiled) method if by far the easiest way to download stories from Wattpad. Choose this option if you aren't sure what to pick.
 
-This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/ZhiFenBL/wpdl-py-cross" "wpdl-py-cross" >}}.
+This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}}.
 
-1) Download the MacOS `.zip` from  [Github](https://github.com/ZhiFenBL/bin-wpdl-py/releases/download/v0.0.1/macos-build-arm64-v0.0.1.zip).
+1) Download the MacOS (arm64) `macos-build-arm64-v*.*.*.zip` from  {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "GitHub" >}}.
 
 2) ???
 
@@ -27,7 +27,7 @@ I don't know. I've never used a Mac, but the file you just downloaded should hav
 
 ### wpdl-py-cross (Python):
 
-This method involves running [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/ZhiFenBL/wpdl-py-cross" "wpdl-py-cross" >}} using a python virtual environment.
+This method involves running [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}} using a python virtual environment.
 
 1) Download and run the {{< linknewtab "https://www.python.org/ftp/python/3.13.5/python-3.13.5-macos11.pkg" "Python installer" >}}.
 

--- a/content/posts/windows.md
+++ b/content/posts/windows.md
@@ -17,9 +17,9 @@ There are six ways to run a Wattpad downloader on Windows: wpd.my, wpdl-py-cross
 
 Using the wpdl-py-cross (precompiled) method if by far the easiest way to download stories from Wattpad. Choose this option if you aren't sure what to pick.
 
-This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/ZhiFenBL/wpdl-py-cross" "wpdl-py-cross" >}}.
+This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "wpdl-py-cross" >}}.
 
-1) Download the Windows `.zip` from  {{< linknewtab "https://github.com/ZhiFenBL/bin-wpdl-py/releases/download/v0.0.1/windows-build-v0.0.1.zip" "GitHub" >}}.
+1) Download the Windows `windows-build-v*.*.*.zip` from  {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "GitHub" >}}.
 
 2) Extract the `.zip` file.
 
@@ -27,7 +27,7 @@ This method involves running a precompiled version of [ZhiFenBL](https://github.
 
 ### wpdl-py-cross (Python):
 
-This method involves running [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/ZhiFenBL/wpdl-py-cross" "wpdl-py-cross" >}} using a python virtual environment.
+This method involves running [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}} using a python virtual environment.
 
 1) Open `PowerShell`.
 

--- a/content/posts/windows.md
+++ b/content/posts/windows.md
@@ -17,7 +17,7 @@ There are six ways to run a Wattpad downloader on Windows: wpd.my, wpdl-py-cross
 
 Using the wpdl-py-cross (precompiled) method if by far the easiest way to download stories from Wattpad. Choose this option if you aren't sure what to pick.
 
-This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "wpdl-py-cross" >}}.
+This method involves running a precompiled version of [ZhiFenBL](https://github.com/ZhiFenBL)'s {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross" "wpdl-py-cross" >}}.
 
 1) Download the Windows `windows-build-v*.*.*.zip` from  {{< linknewtab "https://github.com/WattDownload/wpdl-py-cross/releases/latest" "GitHub" >}}.
 


### PR DESCRIPTION
 - Update `wpdl-py-cross` repo link (moved to WattDownload org)

 - Changed download link to `GitHub repo/releases/latest` so no need to update the documentation every time `wpdl-py-cross` release a new version.
